### PR TITLE
Updated TelegramBotService, fixing #3.

### DIFF
--- a/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
+++ b/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
@@ -7,7 +7,7 @@
     <Authors>BassClefStudio.NET</Authors>
     <PackageProjectUrl>https://github.com/bassclefstudio/Bot-Libraries</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/Bot-Libraries.git</RepositoryUrl>
-    <Version>1.1.0</Version>
+    <Version>1.1.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
+++ b/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
@@ -11,6 +11,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="BassClefStudio.NET.Core" Version="1.4.0" />
     <PackageReference Include="Telegram.Bot" Version="15.7.1" />
   </ItemGroup>
 

--- a/BassClefStudio.NET.Bots.Telegram/TelegramBotService.cs
+++ b/BassClefStudio.NET.Bots.Telegram/TelegramBotService.cs
@@ -55,14 +55,14 @@ namespace BassClefStudio.NET.Bots.Telegram
         /// <param name="sendServices">A collection of <see cref="IBotSendService{TService}"/>s that support this <see cref="TelegramBotService"/>.</param>
         /// <param name="recieveServices">A collection of <see cref="IBotRecieveService{TMessage}"/>s that support this <see cref="TelegramBotService"/>.</param>
         /// <param name="inlineCardServices">A collection of <see cref="IBotInlineCardService{TService}"/>s that support this <see cref="TelegramBotService"/>.</param>
-        public TelegramBotService(TelegramBotOptions options, IEnumerable<IBotSendService<TelegramBotService>> sendServices, IEnumerable<IBotRecieveService<Message>> recieveServices, IEnumerable<IBotInlineCardService<TelegramBotService>> inlineCardServices)
+        public TelegramBotService(TelegramBotOptions options, IEnumerable<IBotSendService<TelegramBotService>> sendServices = null, IEnumerable<IBotRecieveService<Message>> recieveServices = null, IEnumerable<IBotInlineCardService<TelegramBotService>> inlineCardServices = null)
         {
             KnownChats = new List<TelegramChat>();
             KnownUsers = options.KnownUsers.Select(u => new TelegramUser(u)).ToArray();
             AccessToken = options.AccessToken;
-            SendServices = new List<IBotSendService<TelegramBotService>>(sendServices);
-            RecieveServices = new List<IBotRecieveService<Message>>(recieveServices);
-            InlineCardServices = new List<IBotInlineCardService<TelegramBotService>>(inlineCardServices);
+            SendServices = new List<IBotSendService<TelegramBotService>>(sendServices ?? new IBotSendService<TelegramBotService>[0]);
+            RecieveServices = new List<IBotRecieveService<Message>>(recieveServices ?? new IBotRecieveService<Message>[0]);
+            InlineCardServices = new List<IBotInlineCardService<TelegramBotService>>(inlineCardServices ?? new IBotInlineCardService<TelegramBotService>[0]);
             ////Add default services
             SendServices.Add(new TelegramTextSendService());
             SendServices.Add(new TelegramParameterRequestSendService());

--- a/BassClefStudio.NET.Bots.Telegram/TelegramBotService.cs
+++ b/BassClefStudio.NET.Bots.Telegram/TelegramBotService.cs
@@ -4,6 +4,7 @@ using BassClefStudio.NET.Bots.Helpers;
 using BassClefStudio.NET.Bots.Inline;
 using BassClefStudio.NET.Bots.Services;
 using BassClefStudio.NET.Bots.Telegram.ContentServices;
+using BassClefStudio.NET.Core;
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -212,6 +213,8 @@ namespace BassClefStudio.NET.Bots.Telegram
                     CallbackReceived?.Invoke(
                         this,
                         new CallbackReceivedEventArgs(action, fromChat));
+
+                    SynchronousTask answerTask = new SynchronousTask(() => BotClient.AnswerCallbackQueryAsync(e.CallbackQuery.Id));
 
                     if (action.OneTime)
                     {


### PR DESCRIPTION
Fixes #3 by sending an empty acknowledgement response back from the callback while the API sends messages in the `Telegram` package. There is the possible option in the future to allow bots to send information through this response.  