### PR TITLE
Fixed bug with TelegramUser equality check.

### DIFF
--- a/BassClefStudio.NET.Bots.Telegram/TelegramChat.cs
+++ b/BassClefStudio.NET.Bots.Telegram/TelegramChat.cs
@@ -55,7 +55,7 @@ namespace BassClefStudio.NET.Bots.Telegram
         /// </summary>
         public static bool operator ==(TelegramUser a, TelegramUser b)
         {
-            return a.UserId == b.UserId;
+            return a?.UserId == b?.UserId;
         }
 
         /// <summary>


### PR DESCRIPTION
`TelegramUser a != null` was throwing a `NullReferenceException`.