### PR TITLE
Fixed parsing error in Telegram edit message service.

### DIFF
--- a/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
+++ b/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
@@ -7,7 +7,7 @@
     <Authors>BassClefStudio</Authors>
     <PackageProjectUrl>https://github.com/bassclefstudio/Bot-Libraries</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/Bot-Libraries.git</RepositoryUrl>
-    <Version>1.5.2</Version>
+    <Version>1.5.3</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.NET.Bots.Telegram/ContentServices/TelegramTextEditService.cs
+++ b/BassClefStudio.NET.Bots.Telegram/ContentServices/TelegramTextEditService.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading.Tasks;
 using Telegram.Bot;
 using Telegram.Bot.Types;
+using Telegram.Bot.Types.Enums;
 using Telegram.Bot.Types.ReplyMarkups;
 
 namespace BassClefStudio.NET.Bots.Telegram.ContentServices
@@ -33,6 +34,7 @@ namespace BassClefStudio.NET.Bots.Telegram.ContentServices
                     new ChatId(telegramChat.ChatId),
                     int.Parse(message.Id),
                     textMessage.Text,
+                    ParseMode.Html,
                     replyMarkup: new InlineKeyboardMarkup(
                         textMessage.Actions.Select(
                             a => InlineKeyboardButton.WithCallbackData(a.DisplayName, a.Id))));


### PR DESCRIPTION
When the `TelegramBotService` edited a text message, the parsing settings were lost and HTML tags became visible. This has now been fixed.