### PR TITLE
Continuable IBotActions

### DIFF
--- a/BassClefStudio.NET.Bots.AppModel/BassClefStudio.NET.Bots.AppModel.csproj
+++ b/BassClefStudio.NET.Bots.AppModel/BassClefStudio.NET.Bots.AppModel.csproj
@@ -6,7 +6,7 @@
     <PackageProjectUrl>https://github.com/bassclefstudio/Bot-Libraries</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/Bot-Libraries.git</RepositoryUrl>
     <Authors>BassClefStudio</Authors>
-    <Version>1.5.6</Version>
+    <Version>1.6.0</Version>
     <Description>A .NET Standard library that extends BassClefStudio.AppModel to provide some native functionality for bot client apps (with a focus on - but not a requirement for - console apps).</Description>
     <PackageTags>ated</PackageTags>
   </PropertyGroup>

--- a/BassClefStudio.NET.Bots.AppModel/BotViewModel.cs
+++ b/BassClefStudio.NET.Bots.AppModel/BotViewModel.cs
@@ -34,9 +34,12 @@ namespace BassClefStudio.NET.Bots.AppModel
         /// <summary>
         /// Creates a new <see cref="BotViewModel"/> with the required services.
         /// </summary>
-        public BotViewModel(string botName, App myApp, Bot mathSolveBot)
+        /// <param name="botName">The name of the <see cref="Bot"/>.</param>
+        /// <param name="myApp">The AppModel <see cref="App"/> to connect this <see cref="Bot"/> to.</param>
+        /// <param name="myBot">The <see cref="Bot"/> this <see cref="IViewModel"/> will manage.</param>
+        public BotViewModel(string botName, App myApp, Bot myBot)
         {
-            MyBot = mathSolveBot;
+            MyBot = myBot;
             MyApp = myApp;
             BotName = botName;
         }

--- a/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
+++ b/BassClefStudio.NET.Bots.Telegram/BassClefStudio.NET.Bots.Telegram.csproj
@@ -7,7 +7,7 @@
     <Authors>BassClefStudio</Authors>
     <PackageProjectUrl>https://github.com/bassclefstudio/Bot-Libraries</PackageProjectUrl>
     <RepositoryUrl>https://github.com/bassclefstudio/Bot-Libraries.git</RepositoryUrl>
-    <Version>1.5.6</Version>
+    <Version>1.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/BassClefStudio.NET.Bots/Actions/IBotAction.cs
+++ b/BassClefStudio.NET.Bots/Actions/IBotAction.cs
@@ -33,11 +33,6 @@ namespace BassClefStudio.NET.Bots.Actions
         /// Completes the <see cref="IBotAction"/>, indicating a user has invoked it.
         /// </summary>
         void Complete();
-
-        /// <summary>
-        /// A <see cref="Task"/> that will complete if/when the <see cref="IBotAction"/> is invoked.
-        /// </summary>
-        Task AwaitCompletionTask { get; }
     }
 
     /// <summary>
@@ -57,16 +52,6 @@ namespace BassClefStudio.NET.Bots.Actions
     /// </summary>
     public static class BotActionExtensions
     {
-        /// <summary>
-        /// Awaits the completion of any of a collection of <see cref="IBotAction{T}"/>s.
-        /// </summary>
-        /// <param name="actions">The collection of <see cref="IBotAction"/>s to await.</param>
-        public static async Task AwaitCompletionAsync(this IEnumerable<IBotAction> actions)
-        {
-            var completed = await Task.WhenAny(actions.Select(a => a.AwaitCompletionTask));
-            await completed;
-        }
-
         /// <summary>
         /// Awaits the completion of any of a collection of <see cref="IBotAction{T}"/>s and returns the result from the <see cref="IBotAction{T}.AwaitValueTask"/> of that invoked action.
         /// </summary>

--- a/BassClefStudio.NET.Bots/Actions/ResultBotAction.cs
+++ b/BassClefStudio.NET.Bots/Actions/ResultBotAction.cs
@@ -32,8 +32,6 @@ namespace BassClefStudio.NET.Bots.Actions
         private TaskCompletionSource<T> CompletionSource { get; }
         /// <inheritdoc/>
         public Task<T> AwaitValueTask => CompletionSource.Task;
-        /// <inheritdoc/>
-        public Task AwaitCompletionTask => CompletionSource.Task;
 
         /// <summary>
         /// Creates a new <see cref="ResultBotAction{T}"/>.

--- a/BassClefStudio.NET.Bots/BassClefStudio.NET.Bots.csproj
+++ b/BassClefStudio.NET.Bots/BassClefStudio.NET.Bots.csproj
@@ -7,7 +7,7 @@
     <RepositoryUrl>https://github.com/bassclefstudio/Bot-Libraries.git</RepositoryUrl>
     <Authors>BassClefStudio</Authors>
     <Description>A .NET Standard library for managing and dealing with bot communicatoin in a platform-agnostic manner.</Description>
-    <Version>1.5.6</Version>
+    <Version>1.6.0</Version>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fixed some documentation bugs in the `BotViewModel` and added a `ContinuableBotAction` which essentially sets up an event-based continuation (which is actually more performant for optional buttons on messages, despite the changes in #12, most of which I still think were a good idea).